### PR TITLE
Study Groups: Search, Join, Toggle Between Joined & All Groups, Display More Info

### DIFF
--- a/client/src/components/Groups/AllGroups.jsx
+++ b/client/src/components/Groups/AllGroups.jsx
@@ -1,11 +1,10 @@
 import "../Groups/css/AllGroups.css";
 import GroupInfo from "./GroupInfo";
 
-function AllGroups({ groups }) {
-  
+function AllGroups({ showGroups, userName, refreshGroups }) {
   return (
     <div className="AllGroups">
-      {groups.map((group) => (
+      {showGroups.map((group) => (
         <div className="groupCard" key={group.groupId}>
           <div className="groupImg">
             <img
@@ -20,7 +19,11 @@ function AllGroups({ groups }) {
               <h2>{group.groupName}</h2>
             </div>
             <div className="groupMoreInfo">
-              <GroupInfo group={group}/>
+              <GroupInfo
+                group={group}
+                userName={userName}
+                refreshGroups={refreshGroups}
+              />
             </div>
           </div>
         </div>

--- a/client/src/components/Groups/GroupInfo.jsx
+++ b/client/src/components/Groups/GroupInfo.jsx
@@ -1,8 +1,7 @@
-import { useEffect } from "react";
 import "../Groups/css/GroupInfo.css";
 import { useState } from "react";
 
-function GroupInfo( {group}) {
+function GroupInfo({ group, userName, refreshGroups }) {
   const [modalStatus, setModalStatus] = useState(false);
 
   const handleOpen = () => {
@@ -13,9 +12,31 @@ function GroupInfo( {group}) {
     setModalStatus(false);
   };
 
+  const handleJoin = async (event) => {
+    try {
+      const response = await fetch(
+        `http://localhost:3000/group/${group.groupId}/join`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            userName,
+          }),
+        },
+      );
+      const dataNew = await response.json();
+      console.log(dataNew);
+      await refreshGroups();
+    } catch (error) {
+      console.error("ERROR: Creating a new study group ", error);
+    }
+  };
+
   return (
     <div className="GroupInfo">
-      <button onClick={handleOpen}>More Info</button>
+      <button onClick={handleOpen} className="infoButton">
+        More Info
+      </button>
       {modalStatus && (
         <div className="modalOverlayGroup">
           <div className="modalContentGroup">
@@ -46,7 +67,7 @@ function GroupInfo( {group}) {
               </div>
               <div className="joinButton">
                 {/* Only show if not member */}
-                <button>Join Group</button>
+                <button onClick={handleJoin}>Join Group</button>
               </div>
             </div>
           </div>

--- a/client/src/components/Groups/css/GroupInfo.css
+++ b/client/src/components/Groups/css/GroupInfo.css
@@ -70,3 +70,9 @@
     flex-wrap: wrap;
     flex-direction: column;
 }
+
+.GroupInfo {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}

--- a/client/src/components/Groups/css/Groups.css
+++ b/client/src/components/Groups/css/Groups.css
@@ -9,3 +9,8 @@
     flex-direction: row;
     justify-content: center;
 }
+
+.errorMessage {
+    text-align: center;
+    color: red;
+}

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -27,7 +27,7 @@ router.post("/createGroup", async (req, res) => {
   }
 });
 
-
+// SHOW ALL GROUPS
 router.get("/groups", async (req, res) => {
     try {
         const groups = await prisma.groups.findMany({
@@ -40,6 +40,57 @@ router.get("/groups", async (req, res) => {
     } catch (error) {
         console.error("Error: Fetching groups", error)
         res.status(500).json({message: "Error: Fetching groups"})
+    }
+});
+
+// USER JOIN GROUP
+router.post("/group/:id/join", async (req, res) => {
+  const groupId = parseInt(req.params.id);
+ const { userName}  = req.body;
+  try {
+    const updateMembers = await prisma.groups.update({
+      where: {
+        groupId: groupId,
+      },
+      data: {
+        groupMembers: {
+          connect: [{ userName: userName }],
+        },
+      },
+      include: {
+        groupMembers: true,
+      }
+    });
+
+    res.status(200).json(updateMembers);
+  } catch (error) {
+    console.error("Error updating members", error);
+    res.status(500).json({ message: "Error: Updating members" });
+  }
+});
+
+// SHOW ALL USER GROUPS
+router.get("/user/:userName/groups", async (req, res) => {
+    const { userName } = req.params;
+
+    try {
+        const user = await prisma.users.findUnique({
+            where: {
+                userName,
+            },
+            include: {
+                Groups: {
+                  include: {
+                    groupMembers: true,
+                  }
+                }
+            }
+        })
+
+        res.status(200).json(user.Groups);
+    } catch (error) {
+        console.error("Error: Fething user joined groups", error)
+        res.status(500).json({message: "Error: Fetching user joined groups"})
     }
 })
 


### PR DESCRIPTION
## Description
- Added Search Groups Feature (Updates display live on keyboard change) 
- Can clear search by toggling "My Groups", "All Groups" or just removing query with backspace
- Can search in "My Groups" section
- User can join a group and saved in database, DB has a relation feature with Users & Groups so later on I can display on the user profile what groups logged in user is.
- Live sync of showing the user being added to the group

Move Forward:
- Can add a leave group button
- Noticed when demo'ing video that I should add logic so that if I'm already in a group I can't join it again
- Display my groups on user profile
- Add events to groups with location set

## Milestones
- Week 2 Project Plan

## Resources
- Prisma Documentation 
- Previous Capstone Projects
- Stack Overflow

## Test Plan
- Tested with checking Prisma Studio to make sure the relation of the Users and Groups was working so it display on User side what groups they are in and in Groups what users are joined
- Tested syncing visually with creating groups and seeing if they displayed or required a refresh of page. Did the same aswell for joined groups
- Toggling between my groups and searching and toggling back
- Ran into a problem with when I would toggle "My Groups" and try to click "More Info" it wouldn't render but fixed it with fixing the backend route for it by including the Groups then making sure the GroupMembers are included

https://www.loom.com/share/33f325e9895849b1aef657ea78dbc296?sid=7fc058fa-9372-4f20-8d6a-f3484f6126e0