### PR TITLE
Score hosts

### DIFF
--- a/client/src/components/Events/CreateEvent.jsx
+++ b/client/src/components/Events/CreateEvent.jsx
@@ -35,6 +35,7 @@ function CreateEvent({ userName }) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          eventHost: userName,
           eventName: name,
           eventInfo: info,
           eventDate: date,
@@ -48,7 +49,7 @@ function CreateEvent({ userName }) {
         handleClose();
       }
     } catch (error) {
-      console.error("ERROR: Creating a new study group ", error);
+      console.error("ERROR: Creating a new event ", error);
     }
   };
 

--- a/client/src/components/Events/Events.jsx
+++ b/client/src/components/Events/Events.jsx
@@ -143,7 +143,7 @@ function Events({ userName }) {
                   {event.eventGroups?.length === 0 &&
                     event.eventUsers?.length > 0 && (
                       <p>
-                        <b>User Host:</b> {event.eventUsers[0].userName}
+                        <b>User Host:</b> {event.eventHost}
                       </p>
                     )}
                   <p>

--- a/server/prisma/migrations/20250711180509_test/migration.sql
+++ b/server/prisma/migrations/20250711180509_test/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `eventHost` to the `Events` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Events" ADD COLUMN     "eventHost" TEXT NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -40,6 +40,7 @@ model Groups {
 
 model Events {
   eventId       Int       @id @default(autoincrement())
+  eventHost     String
   eventName     String
   eventInfo     String
   eventDate     String

--- a/server/recommendEvents/scoreEvents.js
+++ b/server/recommendEvents/scoreEvents.js
@@ -6,6 +6,8 @@ const {
   scoreSimilarity,
   mapMutuals,
   scoreMutuals,
+  mapHosts,
+  scoreHosts,
 } = require("./scoringMethods");
 
 const scoreWeight = {
@@ -14,7 +16,7 @@ const scoreWeight = {
   info: 0.15,
   dateTime: 0.15,
   location: 0.05,
-  groups: 0.05,
+  hosts: 0.05,
 };
 
 router.get("/user/:userName/scoreEvents", async (req, res) => {
@@ -61,6 +63,8 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
     const pastDescriptions = pastEvents.map((event) => event.eventInfo);
     const pastLocations = pastEvents.map((event) => event.eventLocation);
     const mutualMap = mapMutuals(userName, pastEvents);
+    const hostMap = mapHosts(userName, pastEvents);
+    const totalPastEvents = pastEvents.length;
 
     const scoreEvents = upcomingEvents.map((event) => {
       let titleMax = 0;
@@ -69,6 +73,9 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
       
       const eventUserList = event.eventUsers.map((user) => user.userName);
       const scoreUsers = scoreMutuals(eventUserList, mutualMap, userName);
+
+      const eventHost = event.eventHost;
+      const scoreHost = scoreHosts(eventHost, hostMap, totalPastEvents);
 
       for (const pastTitle of pastTitles) {
         titleMax = Math.max(
@@ -95,7 +102,8 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
         (scoreWeight.title * titleMax) +
         (scoreWeight.info * infoMax) +
         (scoreWeight.location * locationMax) +
-        (scoreWeight.users * scoreUsers);
+        (scoreWeight.users * scoreUsers) +
+        (scoreWeight.hosts * scoreHost);
 
       return {
         eventId: event.eventId,
@@ -104,6 +112,7 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
         scoreInfo: infoMax,
         scoreLocation: locationMax,
         scoreUsers: scoreUsers,
+        scoreHost: scoreHost,
         weightedTotal: weightedTotal,
       };
     });

--- a/server/recommendEvents/scoringMethods.js
+++ b/server/recommendEvents/scoringMethods.js
@@ -33,5 +33,26 @@ export function scoreMutuals(eventUserList, mutualsMap, currentUserName) {
       score += mutualsMap.get(user) || 0;
     }
   }
-  return score / eventUserList.length;
+  return score / mutualsMap.size;
+}
+
+export function mapHosts(user, pastEvents) {
+  const map = new Map();
+
+  for (const event of pastEvents) {
+    const host = event.eventUsers[0].userName;
+    if (host !== user) {
+      map.set(host, (map.get(host) || 0) + 1)
+    }
+  }
+  return map;
+}
+
+
+export function scoreHosts(eventHost, hostMap, totalPastEvents) {
+  if (!eventHost || totalPastEvents.length === 0) {
+    return 0;
+  }
+  const hostTotal = hostMap.get(eventHost) || 0;
+  return hostTotal / totalPastEvents;
 }

--- a/server/recommendEvents/scoringMethods.js
+++ b/server/recommendEvents/scoringMethods.js
@@ -40,7 +40,7 @@ export function mapHosts(user, pastEvents) {
   const map = new Map();
 
   for (const event of pastEvents) {
-    const host = event.eventUsers[0].userName;
+    const host = event.eventHost;
     if (host !== user) {
       map.set(host, (map.get(host) || 0) + 1)
     }

--- a/server/routes/events.js
+++ b/server/routes/events.js
@@ -7,6 +7,7 @@ const prisma = new PrismaClient();
 router.post("/createEvent", async (req, res) => {
   try {
     const {
+      eventHost,
       eventName,
       eventInfo,
       eventDate,
@@ -17,6 +18,7 @@ router.post("/createEvent", async (req, res) => {
     } = req.body;
 
     const eventData = {
+      eventHost,
       eventName,
       eventInfo,
       eventDate,


### PR DESCRIPTION
## Description
- Updated `scoreMutuals` function to divide the score up by the size of all the mutuals of the user (PR #17) comment from Daniel 
- Updated database to hold `eventHost` instead of grabbing the first user in the eventUsers list
- Created helper function `mapHost` which creates a map of all the past events the user has went too, and the hosts of them with the value being the amount they hosted.
- Created helper function `scoreHosts` which creates the score based on the fact of how "familiar" the host is with the user base on previous events attendance. Gets the event host for the current upcoming event then checks the map to see if host is already logged in the map and if so then get the total amount of user attendance for that host. Then divide by the total number of pasts events by the user which gives the score. If host not logged with the user then we just score as an 0.

## Milestones
- Technical Challenge 1 

## Resources

## Test Plan
- Checked DB update with creating new events and made sure it was getting updated to database properly
- Overall tested with checking and messing values of events for users with using Prisma Studio and just the backend route created on Insomnia making sure the scoring was working properly
- Console logging map and values to see it was properly working how I wanted it too
- Checked `event.eventHost` worked properly by checking the UI for displaying events

<img width="400" height="431" alt="image" src="https://github.com/user-attachments/assets/fc66af30-dbde-447d-80a6-8ab451fee5c3" />
<img width="349" height="111" alt="image" src="https://github.com/user-attachments/assets/1404c322-ae4b-485c-a9fd-86f46125c247" />
<img width="1629" height="215" alt="image" src="https://github.com/user-attachments/assets/12bcf54e-1e7d-473b-9ce3-7cee9fddd0d5" />