### PR TITLE
TC # 1 Fixes

### DIFF
--- a/client/src/components/Events/CalendarEvents.jsx
+++ b/client/src/components/Events/CalendarEvents.jsx
@@ -1,4 +1,4 @@
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import "../Events/css/CalendarEvents.css";
 import EventCard from "./EventCard";
 import formatDateTime from "../../utils";
@@ -169,7 +169,8 @@ function CalendarEvents({ userName }) {
           ) : (
             <div className="timelineContainer">
               <div className="timelineLine"></div>
-              {filteredEvents.map((event) => (
+              {[...filteredEvents].sort((a,b) => new Date(a.eventDate) - new Date(b.eventDate))
+              .map((event) => (
                 <EventCard
                   event={event}
                   userName={userName}

--- a/client/src/components/Events/CreateEvent.jsx
+++ b/client/src/components/Events/CreateEvent.jsx
@@ -102,7 +102,7 @@ function CreateEvent({ userName }) {
                 placeholder="Enter Event Location"
               />
               <input
-                type="text"
+                type="number"
                 name="eventLength"
                 required
                 placeholder="Enter Event Length (Hours)"

--- a/client/src/components/Events/RecommendedEvents.jsx
+++ b/client/src/components/Events/RecommendedEvents.jsx
@@ -69,11 +69,7 @@ function RecommendedEvents({ userName }) {
           <p>Sorry, you don't have any recommended events at this moment!</p>
         ) : (
           [...recommended]
-            .sort((a, b) => {
-              const scoreA = a.scoreTitle + a.scoreInfo + a.scoreLocation;
-              const scoreB = b.scoreTitle + b.scoreInfo + b.scoreLocation;
-              return scoreB - scoreA;
-            })
+            .sort((a, b) => b.weightedTotal - a.weightedTotal)
             .slice(0, 5)
             .map((event) => (
               <EventCard

--- a/client/src/components/Events/css/CreateEvent.css
+++ b/client/src/components/Events/css/CreateEvent.css
@@ -9,6 +9,7 @@
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
+    z-index: 10;
 }
 
 .modalContentEvent {
@@ -80,6 +81,18 @@ input[type=eventLoco] {
 }
 
 input[type=datetime-local] {
+    border-radius: 15px;
+    padding: 12px 20px;
+    margin: 8px 0;
+    display: inline-block;
+    box-sizing: border-box;
+    width: 250px;
+    border: none;
+    margin-top: 15px;
+    margin-bottom: 15px;
+}
+
+input[type=number] {
     border-radius: 15px;
     padding: 12px 20px;
     margin: 8px 0;

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -1,11 +1,13 @@
-function formattedDate(release_date) {
+function formattedDate(date) {
   const options = {
     weekday: "long",
     year: "numeric",
     month: "long",
     day: "numeric",
   };
-  return new Date(release_date).toLocaleDateString(undefined, options);
+  const [year, month, day] = date.split('-');
+  const dateFormatted = new Date(year, month -1, day);
+  return dateFormatted.toLocaleDateString(undefined, options);
 };
 
 function formattedTime(eventDate) {

--- a/server/recommendEvents/scoreEvents.js
+++ b/server/recommendEvents/scoreEvents.js
@@ -83,6 +83,9 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
       const scoreHost = scoreHosts(eventHost, hostMap, totalPastEvents);
       const scoreDay = scoreDays(event.eventDate, dayMap, totalPastEvents);
       const scoreAvbl = scoreAvailability(event, rsvpEvents);
+      if (scoreAvbl === 0) {
+        return null;
+      }
 
       for (const pastTitle of pastTitles) {
         titleMax = Math.max(
@@ -126,7 +129,7 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
         eventImg: event.eventImg,
         weightedTotal: weightedTotal,
       };
-    });
+    }).filter((event) => event !== null);
 
     res.status(200).json(scoreEvents);
   } catch (error) {

--- a/server/recommendEvents/scoreEvents.js
+++ b/server/recommendEvents/scoreEvents.js
@@ -37,12 +37,12 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
                 members: {
                   include: {
                     user: true,
-                  }
-                }
-              }
-            }
-          }
-        }
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     });
 
@@ -70,78 +70,88 @@ router.get("/user/:userName/scoreEvents", async (req, res) => {
     const pastEvents = user.Events.filter(
       (event) => event.eventDate < currentDate
     );
-    const allGroupMutuals = user.members.map((member) => member.group);
+    const userGroups = user.members.map((member) => member.group);
     const pastTitles = pastEvents.map((event) => event.eventName);
     const pastDescriptions = pastEvents.map((event) => event.eventInfo);
     const pastLocations = pastEvents.map((event) => event.eventLocation);
     const mutualMap = mapMutuals(userName, pastEvents);
-    const mutualGroupMembers = mapGroupMutuals(userName, allGroupMutuals);
+    const groupMemberMap = mapGroupMutuals(userName, userGroups);
     const hostMap = mapHosts(userName, pastEvents);
     const dayMap = mapDays(pastEvents);
     const totalPastEvents = pastEvents.length;
-    const groupMembersSize = mutualGroupMembers.size;
+    const groupMembersSize = groupMemberMap.size;
 
-    const scoreEvents = nonRsvpEvents.map((event) => {
-      let titleMax = 0;
-      let infoMax = 0;
-      let locationMax = 0;
-      
-      const eventUserList = event.eventUsers.map((user) => user.userName);
-      const scoreUsers = scoreMutuals(eventUserList, mutualMap, userName);
-      const scoreGroupMembers = scoreGroupMutuals(eventUserList, mutualGroupMembers, userName);
-      const eventHost = event.eventHost;
-      const scoreHost = scoreHosts(eventHost, hostMap, totalPastEvents);
-      const scoreDay = scoreDays(event.eventDate, dayMap, totalPastEvents);
-      const scoreAvbl = scoreAvailability(event, rsvpEvents);
-      if (scoreAvbl === 0 && rsvpEvents.length > 0) {
-        return null;
-      }
+    const scoreEvents = nonRsvpEvents
+      .map((event) => {
+        let titleScore = 0;
+        let infoScore = 0;
+        let locationScore = 0;
 
-      for (const pastTitle of pastTitles) {
-        titleMax = Math.max(
-          titleMax,
-          scoreSimilarity(event.eventName, pastTitle)
+        const eventUserNames = event.eventUsers.map((user) => user.userName);
+        const mutualUserScore = scoreMutuals(
+          eventUserNames,
+          mutualMap,
+          userName
         );
-      }
-
-      for (const pastDescription of pastDescriptions) {
-        infoMax = Math.max(
-          infoMax,
-          scoreSimilarity(event.eventInfo, pastDescription)
+        const groupMutualScore = scoreGroupMutuals(
+          eventUserNames,
+          groupMemberMap,
+          userName
         );
-      }
+        const eventHost = event.eventHost;
+        const hostScore = scoreHosts(eventHost, hostMap, totalPastEvents);
+        const dayScore = scoreDays(event.eventDate, dayMap, totalPastEvents);
+        const availabilityScore = scoreAvailability(event, rsvpEvents);
+        if (availabilityScore === 0 && rsvpEvents.length > 0) {
+          return null;
+        }
 
-      for (const pastLocation of pastLocations) {
-        locationMax = Math.max(
-          locationMax,
-          scoreSimilarity(event.eventLocation, pastLocation)
-        );
-      }
+        for (const pastTitle of pastTitles) {
+          titleScore = Math.max(
+            titleScore,
+            scoreSimilarity(event.eventName, pastTitle)
+          );
+        }
 
-      const scoreWeight = getScoreWeight(totalPastEvents, groupMembersSize);
-      const weightedTotal =
-        scoreWeight.title * titleMax +
-        scoreWeight.info * infoMax +
-        scoreWeight.location * locationMax +
-        scoreWeight.users * scoreUsers +
-        scoreWeight.hosts * scoreHost +
-        scoreWeight.days * scoreDay +
-        scoreWeight.availability * scoreAvbl +
-        scoreWeight.groupMembers * scoreGroupMembers;
+        for (const pastDescription of pastDescriptions) {
+          infoScore = Math.max(
+            infoScore,
+            scoreSimilarity(event.eventInfo, pastDescription)
+          );
+        }
 
-      return {
-        eventId: event.eventId,
-        eventName: event.eventName,
-        eventLocation: event.eventLocation,
-        eventLength: event.eventLength,
-        eventDate: event.eventDate,
-        eventUsers: event.eventUsers,
-        eventHost: event.eventHost,
-        eventInfo: event.eventInfo,
-        eventImg: event.eventImg,
-        weightedTotal: weightedTotal,
-      };
-    }).filter((event) => event !== null);
+        for (const pastLocation of pastLocations) {
+          locationScore = Math.max(
+            locationScore,
+            scoreSimilarity(event.eventLocation, pastLocation)
+          );
+        }
+
+        const scoreWeight = getScoreWeight(totalPastEvents, groupMembersSize);
+        const weightedTotal =
+          scoreWeight.title * titleScore +
+          scoreWeight.info * infoScore +
+          scoreWeight.location * locationScore +
+          scoreWeight.users * mutualUserScore +
+          scoreWeight.hosts * hostScore +
+          scoreWeight.days * dayScore +
+          scoreWeight.availability * availabilityScore +
+          scoreWeight.groupMembers * groupMutualScore;
+
+        return {
+          eventId: event.eventId,
+          eventName: event.eventName,
+          eventLocation: event.eventLocation,
+          eventLength: event.eventLength,
+          eventDate: event.eventDate,
+          eventUsers: event.eventUsers,
+          eventHost: event.eventHost,
+          eventInfo: event.eventInfo,
+          eventImg: event.eventImg,
+          weightedTotal: weightedTotal,
+        };
+      })
+      .filter((event) => event !== null);
 
     res.status(200).json(scoreEvents);
   } catch (error) {

--- a/server/recommendEvents/scoringMethods.js
+++ b/server/recommendEvents/scoringMethods.js
@@ -10,40 +10,47 @@ export function scoreSimilarity(upcomingEvents, pastEvents) {
 }
 
 export function mapMutuals(user, pastEvents) {
-  const eventsPerWeekday = new Map();
+  const mutualsCountMap = new Map();
 
   for (const event of pastEvents) {
     for (const mutual of event.eventUsers.map((user) => user.userName)) {
       if (mutual !== user) {
-        eventsPerWeekday.set(mutual, (eventsPerWeekday.get(mutual) || 0) + 1);
+        mutualsCountMap.set(mutual, (mutualsCountMap.get(mutual) || 0) + 1);
       }
     }
   }
-  return eventsPerWeekday;
+  return mutualsCountMap;
 }
 
 export function mapGroupMutuals(user, allGroupMutuals) {
-  const groupMutualsMap = new Map();
+  const groupMutualsCountMap = new Map();
 
   for (const group of allGroupMutuals) {
     for (const member of group.members) {
       const groupMemberName = member.user.userName;
       if (groupMemberName !== user) {
-        groupMutualsMap.set(groupMemberName, (groupMutualsMap.get(groupMemberName) || 0) + 1)
+        groupMutualsCountMap.set(
+          groupMemberName,
+          (groupMutualsCountMap.get(groupMemberName) || 0) + 1
+        );
       }
     }
   }
-  return groupMutualsMap;
+  return groupMutualsCountMap;
 }
 
-export function scoreGroupMutuals(eventUserList, groupMutualMap, currentUserName) {
+export function scoreGroupMutuals(
+  eventUserList,
+  groupMutualMap,
+  currentUserName
+) {
   let score = 0;
   for (const user of eventUserList) {
     if (user !== currentUserName) {
       score += groupMutualMap.get(user) || 0;
     }
   }
-  return (score / groupMutualMap.size || 0);
+  return score / groupMutualMap.size || 0;
 }
 
 export function scoreMutuals(eventUserList, mutualsMap, currentUserName) {
@@ -57,19 +64,19 @@ export function scoreMutuals(eventUserList, mutualsMap, currentUserName) {
       score += mutualsMap.get(user) || 0;
     }
   }
-  return (score / mutualsMap.size) || 0;
+  return score / mutualsMap.size || 0;
 }
 
 export function mapHosts(user, pastEvents) {
-  const map = new Map();
+  const hostsCountMap = new Map();
 
   for (const event of pastEvents) {
     const host = event.eventHost;
     if (host !== user) {
-      map.set(host, (map.get(host) || 0) + 1)
+      hostsCountMap.set(host, (hostsCountMap.get(host) || 0) + 1);
     }
   }
-  return map;
+  return hostsCountMap;
 }
 
 export function scoreHosts(eventHost, hostMap, totalPastEvents) {
@@ -77,27 +84,27 @@ export function scoreHosts(eventHost, hostMap, totalPastEvents) {
     return 0;
   }
   const hostTotal = hostMap.get(eventHost) || 0;
-  return (hostTotal / totalPastEvents) || 0;
+  return hostTotal / totalPastEvents || 0;
 }
 
 export function mapDays(pastEvents) {
-  const map = new Map();
+  const daysCountMap = new Map();
 
   for (const event of pastEvents) {
     const date = new Date(event.eventDate);
     const eventWeekday = date.toLocaleString("en-US", { weekday: "long" });
-    map.set(eventWeekday, (map.get(eventWeekday) || 0) + 1);
+    daysCountMap.set(eventWeekday, (daysCountMap.get(eventWeekday) || 0) + 1);
   }
-  return map;
+  return daysCountMap;
 }
 
-export function scoreDays(eventDate, mapDays, totalPastEvents) {
+export function scoreDays(eventDate, daysCountMap, totalPastEvents) {
   if (!eventDate || totalPastEvents.length === 0) {
     return 0;
   }
   const date = new Date(eventDate);
   const eventWeekday = date.toLocaleString("en-US", { weekday: "long" });
-  const totalEventsOnEventWeekday = mapDays.get(eventWeekday) || 0;
+  const totalEventsOnEventWeekday = daysCountMap.get(eventWeekday) || 0;
   return totalEventsOnEventWeekday / totalPastEvents || 0;
 }
 
@@ -108,12 +115,15 @@ export function scoreAvailability(event, rsvpEvents) {
 
   const SECONDS_IN_HOUR = 1000 * 60 * 60;
   const eventStartTime = new Date(event.eventDate).getTime();
-  const eventEndTime = eventStartTime + (event.eventLength || 1) * SECONDS_IN_HOUR; 
+  const eventEndTime =
+    eventStartTime + (event.eventLength || 1) * SECONDS_IN_HOUR;
 
   for (const rsvp of rsvpEvents) {
     const rsvpEventStartTime = new Date(rsvp.eventDate).getTime();
-    const rsvpEventEndTime = rsvpEventStartTime + (rsvp.eventLength || 1) * SECONDS_IN_HOUR;
-    const eventIsOverlapping = eventStartTime < rsvpEventEndTime && eventEndTime > rsvpEventStartTime;
+    const rsvpEventEndTime =
+      rsvpEventStartTime + (rsvp.eventLength || 1) * SECONDS_IN_HOUR;
+    const eventIsOverlapping =
+      eventStartTime < rsvpEventEndTime && eventEndTime > rsvpEventStartTime;
     if (eventIsOverlapping) {
       return 0.0;
     }
@@ -127,9 +137,9 @@ export function scoreAvailability(event, rsvpEvents) {
 
   const minGapAfterRSVPEvent = Math.min(...gapAfterRSVPEvents);
 
-  if (minGapAfterRSVPEvent > 24) return 0.10;
+  if (minGapAfterRSVPEvent > 24) return 0.1;
   if (minGapAfterRSVPEvent > 12) return 0.25;
-  if (minGapAfterRSVPEvent > 6) return 0.50;
+  if (minGapAfterRSVPEvent > 6) return 0.5;
   if (minGapAfterRSVPEvent > 3) return 0.75;
   return 1.0;
 }
@@ -164,7 +174,7 @@ export function getScoreWeight(totalPastEvents, groupMembersSize) {
     availability: 0.25,
     users: 0.15,
     groupMembers: 0.15,
-    location: 0.10,
+    location: 0.1,
     info: 0.05,
     days: 0.025,
     hosts: 0.025,

--- a/server/recommendEvents/scoringMethods.js
+++ b/server/recommendEvents/scoringMethods.js
@@ -22,6 +22,30 @@ export function mapMutuals(user, pastEvents) {
   return eventsPerWeekday;
 }
 
+export function mapGroupMutuals(user, allGroupMutuals) {
+  const groupMutualsMap = new Map();
+
+  for (const group of allGroupMutuals) {
+    for (const member of group.members) {
+      const groupMemberName = member.user.userName;
+      if (groupMemberName !== user) {
+        groupMutualsMap.set(groupMemberName, (groupMutualsMap.get(groupMemberName) || 0) + 1)
+      }
+    }
+  }
+  return groupMutualsMap;
+}
+
+export function scoreGroupMutuals(eventUserList, groupMutualMap, currentUserName) {
+  let score = 0;
+  for (const user of eventUserList) {
+    if (user !== currentUserName) {
+      score += groupMutualMap.get(user) || 0;
+    }
+  }
+  return (score / groupMutualMap.size || 0);
+}
+
 export function scoreMutuals(eventUserList, mutualsMap, currentUserName) {
   let score = 0;
   if (eventUserList.length === 0) {
@@ -108,4 +132,41 @@ export function scoreAvailability(event, rsvpEvents) {
   if (minGapAfterRSVPEvent > 6) return 0.50;
   if (minGapAfterRSVPEvent > 3) return 0.75;
   return 1.0;
+}
+
+export function getScoreWeight(totalPastEvents, groupMembersSize) {
+  if (totalPastEvents === 0 && groupMembersSize === 0) {
+    return {
+      title: 0,
+      availability: 1,
+      users: 0,
+      groupMembers: 0,
+      location: 0,
+      info: 0,
+      days: 0,
+      hosts: 0,
+    };
+  }
+  if (totalPastEvents === 0) {
+    return {
+      title: 0,
+      availability: 0.5,
+      users: 0,
+      groupMembers: 0.5,
+      location: 0,
+      info: 0,
+      days: 0,
+      hosts: 0,
+    };
+  }
+  return {
+    title: 0.25,
+    availability: 0.25,
+    users: 0.15,
+    groupMembers: 0.15,
+    location: 0.10,
+    info: 0.05,
+    days: 0.025,
+    hosts: 0.025,
+  };
 }


### PR DESCRIPTION
## Description
- Updated: Score Availability, so it properly score users on there availability meaning taking into factor the start time and end time of each event and also the start and end time of RSVP events. Which now if there is an overlap then it auto gives the event a 0 and it won't be recommended to the user. Added a check in the route if there is an overlap to not suggest the event to the user since they are busy.
`  if (minGapAfterRSVPEvent > 24) return 0.1;
  if (minGapAfterRSVPEvent > 12) return 0.25;
  if (minGapAfterRSVPEvent > 6) return 0.5;
  if (minGapAfterRSVPEvent > 3) return 0.75;
  return 1.0;` 
  - Added: Group members signal which grabs the users groups and maps out all the mutuals the user has with being in a group with others and then just adds a score based on how many "mutuals" are attending that event out of all group mutuals.
  - Updated: Weight system so if the user has no past events then it will still score the user off of availability and group mutuals and if they don't have any groups they are in then we just base off of the availability. Then weights just bounce and increase to others since majority of the weights and signals rely off of past events but this still allows suggestions for new users who haven't attended an event.
  - Updated: Weights for each signals
  `    title: 0.25,
    availability: 0.25,
    users: 0.15,
    groupMembers: 0.15,
    location: 0.1,
    info: 0.05,
    days: 0.025,
    hosts: 0.025,`
  - Updated: Events calendar to display the events in time order
  - Updated: Variable names to make code clearer to understand 

## Milestones
- Technical Challenge 1 

## Resources
- MDN Web Documentation 

## Test Plan
- Tested new signal by tested with database and added and removing groups to see if it was correctly scoring the group mutuals signal.
- Checked map with console logs and changed group members in DB
- Added console logs and verified all new or updated code was preforming as expected


