### PR TITLE
Lowest Population Algo Fix & Cluster Icons

### DIFF
--- a/client/src/components/Home/BarChart.jsx
+++ b/client/src/components/Home/BarChart.jsx
@@ -25,7 +25,7 @@ const BarChart = ({ counts }) => {
         labels: dayLabels,
         datasets: [
           {
-            label: "Past User's",
+            label: "Past Users",
             data: counts,
             backgroundColor: "#3148F6",
             borderColor: "#1C4B8F",

--- a/client/src/components/Home/css/HomePage.css
+++ b/client/src/components/Home/css/HomePage.css
@@ -37,10 +37,10 @@
 
 .highestPopulatedMarker {
     color: green;
-    font-size: 3rem;
+    font-size: 2rem;
 }
 
 .leastPopulatedMarker {
     color: orangered;
-    font-size: 3rem;
+    font-size: 2rem;
 }

--- a/server/mapAnalytics/gridCluster.js
+++ b/server/mapAnalytics/gridCluster.js
@@ -5,25 +5,21 @@ const prisma = new PrismaClient();
 const {
   convertBorder,
   createGrid,
-  checkPoint,
+  checkPointWithinBoundary,
   createClusters,
   getBiggestCluster,
   getCentroid,
   getLowestPopulation,
+  groupUsersByGrid,
+  mapBorder,
 } = require("./utils");
-
-const mapBorder = {
-  polygon: [
-    { lat: 37.48188439982738, lng: -122.15137870228908 },
-    { lat: 37.480519446100864, lng: -122.15077332026456 },
-    { lat: 37.47982552151212, lng: -122.16782010873156 },
-    { lat: 37.48215891264268, lng: -122.16750300387568 },
-  ],
-};
 
 router.get("/gridCluster", async (req, res) => {
   const locations = await prisma.map.findMany({
+    where: { status: "ACTIVE" },
     select: {
+      mapUserName: true,
+      createTime: true,
       mapLat: true,
       mapLong: true,
     },
@@ -34,7 +30,7 @@ router.get("/gridCluster", async (req, res) => {
 
   for (const loc of locations) {
     for (const cell of grid) {
-      if (checkPoint(loc, cell)) {
+      if (checkPointWithinBoundary(loc, cell)) {
         cell.count += 1;
       }
     }
@@ -44,13 +40,13 @@ router.get("/gridCluster", async (req, res) => {
   const biggestCluster = getBiggestCluster(clusters);
   const lowestPopulatedLocation = getLowestPopulation(grid, clusters);
   const highestPopulatedLocation = getCentroid(biggestCluster);
+  const groupedMarkers = groupUsersByGrid(locations, grid);
 
   res.json({
     highestPopulated: highestPopulatedLocation,
     leastPopulated: lowestPopulatedLocation,
     biggestCluster,
-    clusters: clusters,
-    grid: grid,
+    groupedMarkers,
   });
 });
 

--- a/server/mapAnalytics/mapHistory.js
+++ b/server/mapAnalytics/mapHistory.js
@@ -5,18 +5,10 @@ const prisma = new PrismaClient();
 const {
   convertBorder,
   createGrid,
-  checkPoint,
+  checkPointWithinBoundary,
   getNeighborIndices,
+  mapBorder,
 } = require("./utils");
-
-const mapBorder = {
-  polygon: [
-    { lat: 37.48188439982738, lng: -122.15137870228908 },
-    { lat: 37.480519446100864, lng: -122.15077332026456 },
-    { lat: 37.47982552151212, lng: -122.16782010873156 },
-    { lat: 37.48215891264268, lng: -122.16750300387568 },
-  ],
-};
 
 router.post("/checkCellLocation", async (req, res) => {
   const COLS = 20;
@@ -36,11 +28,11 @@ router.post("/checkCellLocation", async (req, res) => {
       const day = date.getUTCDay();
 
       for (const cell of grid) {
-        if (checkPoint(loc, cell)) {
+        if (checkPointWithinBoundary(loc, cell)) {
           cell.totalCount += 1;
           if (!cell.totalLocations) cell.totalLocations = [];
           cell.totalLocations.push(loc);
-          if (checkPoint(clickedPoint, cell)) {
+          if (checkPointWithinBoundary(clickedPoint, cell)) {
             dayCounts[day]++;
           }
           break;
@@ -48,7 +40,9 @@ router.post("/checkCellLocation", async (req, res) => {
       }
     }
 
-    const matchingCell = grid.find((cell) => checkPoint(clickedPoint, cell));
+    const matchingCell = grid.find((cell) =>
+      checkPointWithinBoundary(clickedPoint, cell)
+    );
     const neighbors = getNeighborIndices(matchingCell);
     const allCells = [
       matchingCell,
@@ -56,7 +50,7 @@ router.post("/checkCellLocation", async (req, res) => {
     ];
 
     const overallTotalCount = locations.filter((loc) =>
-      allCells.some((cell) => checkPoint(loc, cell))
+      allCells.some((cell) => checkPointWithinBoundary(loc, cell))
     ).length;
 
     res.json({


### PR DESCRIPTION
## Description
- Updated: `getLowestPopulation` function so it properly suggests the lowest populated location. Changed the functionality up so it searches and gets the shortest distance to a cluster and the shortest distance to a border. With those we then score for that cell by multiplying both and getting our score, the higher the score the better. Added `getBorderPoints` function so I could get the border points to use for the calculation. 
- Updated: User map icons to allow them to group as a cluster (group icon) if there are more than one user in an area. Added `groupUsersByGrid` which just groups the users together depending on there location and if there are near each other. Which then gets sent to the front end where it will either group the users together or keep them in there icons depending on if there are any users near them. Also updated so the gridCluster any handles "ACTIVE" map data.
- Small TC 2 related PR fixes like naming of function and moving the `mapBorder` to utils as it was twice in the backend.

## Milestones
- Technical Challenge 2 

## Resources
- MDN Web Documentation 

## Test Plan
- Tested the new lowest population functionality by testing with setting new data points and moving them around and seeing how the location would change, and based on how I discussed it with Sherry it was preforming how I wanted it too.
- Tested the clustering groups by just setting locations of users really close to each other to see if they would get paired to each other.
- Notice the lowest population location was getting effected from "PAST" data, so made sure it only handled "ACTIVE" data.
- Checked console logs when changing and modifying my functionality 

https://drive.google.com/file/d/1xMbTJnK8Yl9Ok9j3uHLSIXEL4XDuN2F2/view?usp=sharing 